### PR TITLE
Correct Spell Dialog for College of Satire

### DIFF
--- a/WotC material/v13/ua_20160104_Kits-of-Old.js
+++ b/WotC material/v13/ua_20160104_Kits-of-Old.js
@@ -79,7 +79,7 @@ AddSubClass("bard", "college of satire", {
 			usagescalc : "event.value = Math.max(1, What('Cha Mod'));",
 			recovery : "long rest",
 			spellcastingBonus : {
-				name : "Spirit Walker",
+				name : "Fool's Insight",
 				spells : ["detect thoughts"],
 				selection : ["detect thoughts"],
 				firstCol : "(S)"


### PR DESCRIPTION
Correct the name displayed on the spell dialog for the College of Satire's spellcasting bonus.